### PR TITLE
better to run the container in '-it' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ docker build -t nvidia-anaconda-docker <PATH_TO_DOCKERFILE_ROOT_PATH>
 
 ### Running container
 ```
-nvidia-docker run -v <HOST_NOTEBOOK_DIR>:/tmp -p 8888:8888 nvidia-anaconda-docker
+nvidia-docker run -v <HOST_NOTEBOOK_DIR>:/tmp -p 8888:8888 -it nvidia-anaconda-docker
 ```
 
 #### From [Dockerhub image](https://hub.docker.com/r/luke035/nvidia-anaconda-docker/)
 ```
-nvidia-docker run -v <HOST_NOTEBOOK_DIR>:/tmp -p 8888:8888 luke035/nvidia-anaconda-docker
+nvidia-docker run -v <HOST_NOTEBOOK_DIR>:/tmp -p 8888:8888 -it luke035/nvidia-anaconda-docker
 ```
 
 ### Notes


### PR DESCRIPTION
if you don't run in `-it` interactive way, it will be pretty hard to `control+c` to turn the notebook server off. 